### PR TITLE
chore: example for APIG V2 API aka HTTP API and support in  validateL…

### DIFF
--- a/examples/basic/handler.js
+++ b/examples/basic/handler.js
@@ -9,9 +9,21 @@ module.exports.root = async (event, context) => {
   return fileHandler.get(event, context)
 }
 
+module.exports.v2_root = async (event, context) => {
+  event.rawPath = "index.html" // forcing a specific page for this handler; ignore requested path
+  return fileHandler.get(event, context)
+}
+
 module.exports.binary = async (event, context) => {
   if (!event.path.startsWith("/binary/")) {
-    throw new Error(`[404] Invalid filepath for this resource: ${fname}`)
+    throw new Error(`[404] Invalid filepath for this resource`)
+  }
+  return fileHandler.get(event, context)
+}
+
+module.exports.v2_binary = async (event, context) => {
+  if (!event.rawPath.startsWith("/v2/binary/")) {
+    throw new Error(`[404] Invalid filepath for this resource`)
   }
   return fileHandler.get(event, context)
 }

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -8,7 +8,10 @@
     "deploy": "serverless deploy --aws-profile serverless",
     "destroy": "serverless remove --aws-profile serverless",
     "lint": "prettier --write \"./**/*.{js,md,yml,json,html}\"",
-    "reset": "rm -rfd ./node_modules/ && npm i && npm run deploy"
+    "reset": "rm -rfd ./node_modules/ && npm i && npm run deploy",
+    "//dev-link": "Useful for debugging but don't commit it in this way; use `npm run dev-unlink` before committing. NOTE: Not using `npm link` or `npm add ../..` because that creates a filesystem symlink and serverless.com freaks out when attempting a deploy with a symlinked dependency.",
+    "dev-link": "pushd . ; cd ../.. ; npm pack ; popd ; npm add ../../serverless-aws-static-file-handler-0.0.0.tgz",
+    "dev-unlink": "npm rm serverless-aws-static-file-handler ; npm add serverless-aws-static-file-handler@>=3.0.2-beta.1"
   },
   "devDependencies": {
     "serverless": "^2.52.1"

--- a/examples/basic/serverless.yml
+++ b/examples/basic/serverless.yml
@@ -29,3 +29,18 @@ functions:
       - http:
           path: /binary/{pathvar+}
           method: get
+
+  # API Gateway V2 Payload or HTTP API are below. As described at https://www.serverless.com/framework/docs/providers/aws/events/http-api
+  v2_html:
+    handler: handler.v2_root
+    events:
+      - httpApi:
+          path: /v2
+          method: get
+
+  v2_binary:
+    handler: handler.v2_binary
+    events:
+      - httpApi:
+          path: /v2/binary/{pathvar+}
+          method: get

--- a/src/StaticFileHandler.js
+++ b/src/StaticFileHandler.js
@@ -5,7 +5,7 @@ const mimetypes = require("mime-types")
 const Mustache = require("mustache")
 const path = require("path")
 const util = require("util")
-
+const _ = require("lodash")
 const readFileAsync = util.promisify(fs.readFile)
 const accessAsync = util.promisify(fs.access)
 
@@ -239,32 +239,44 @@ class StaticFileHandler {
    * Rejects if the specified event is not Lambda Proxy integration
    */
   static async validateLambdaProxyIntegration(event) {
-    // From https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
-    const expectedProps = [
-      "resource",
-      "path",
-      "httpMethod",
-      "headers",
-      "multiValueHeaders",
-      "queryStringParameters",
-      "multiValueQueryStringParameters",
-      "pathParameters",
-      "stageVariables",
-      "requestContext",
-      "body",
-      "isBase64Encoded",
-    ]
-    const missingProps = expectedProps.filter(
-      (propName) => !(propName in event)
-    )
-    // We're using serverless-offline which doesn't provide the `isBase64Encoded` prop, but does add the isOffline. Fixes issue #10: https://github.com/activescott/serverless-aws-static-file-handler/issues/10
-    const isServerlessOfflineEnvironment =
-      missingProps.length === 1 &&
-      missingProps[0] === "isBase64Encoded" &&
-      "isOffline" in event
-    if (missingProps.length > 0 && !isServerlessOfflineEnvironment) {
+    /* 
+    There are two different event schemas in API Gateway + Lambda Proxy APIs. One is known as "REST API" or the old V1 API and the newer one is the V2 or "HTTP API". 
+    Each are described at https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html#services-apigateway-apitypes
+    You can see examples of each at https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+    TLDR: 
+    - V2 has a { version: "2.0" } field and { requestContext.http.method: "..." }  field.
+    - V1 has a { version: "1.0" } field and { requestContext.httpMethod: "..." }  field.
+    To set each up in serverless.com:
+    - V1: https://www.serverless.com/framework/docs/providers/aws/events/apigateway
+    - V2: https://www.serverless.com/framework/docs/providers/aws/events/http-api
+    */
+    function isV2ProxyAPI(evt) {
+      return (
+        evt.version === "2.0" &&
+        typeof _.get(evt, "requestContext.http.method") === "string"
+      )
+    }
+    function isV1ProxyAPI(evt) {
+      return (
+        // docs say there is a .version but there isn't!
+        // evt.version === "1.0" &&
+        typeof _.get(evt, "requestContext.httpMethod") === "string"
+      )
+    }
+    // serverless-offline doesn't provide the `isBase64Encoded` prop, but does add the isOffline. Fixes issue #10: https://github.com/activescott/serverless-aws-static-file-handler/issues/10
+    const isServerlessOfflineEnvironment = "isOffline" in event
+    if (!isV1ProxyAPI(event) && !isV2ProxyAPI(event)) {
+      const logProps = [
+        "version",
+        "requestContext.httpMethod",
+        "requestContext.http.method",
+      ]
+      const addendum = logProps
+        .map((propName) => `event.${propName} was '${_.get(event, propName)}'`)
+        .join(" ")
       throw new Error(
-        `API Gateway method does not appear to be setup for Lambda Proxy Integration. Please confirm that \`integration\` property of the http event is not specified or set to \`integration: proxy\`. Missing lambda proxy property was ${missingProps[0]}`
+        "API Gateway method does not appear to be setup for Lambda Proxy Integration. Please confirm that `integration` property of the http event is not specified or set to `integration: proxy`." +
+          addendum
       )
     }
   }

--- a/src/test/StaticFileHandler.js
+++ b/src/test/StaticFileHandler.js
@@ -16,13 +16,15 @@ function mockEvent(event) {
   return {
     resource: null,
     httpMethod: "GET",
+    requestContext: {
+      httpMethod: "GET",
+    },
     headers: {},
     multiValueHeaders: {},
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
     pathParameters: null,
     stageVariables: null,
-    requestContext: {},
     body: null,
     isBase64Encoded: false,
     ...event,


### PR DESCRIPTION
@tomchiverton I took some time to create an example using the V2 HTTP API via serverless.com. Along the way I found `validateLambdaProxyIntegration` was problematic working with the V2 HTTP API so I made some updates there. 

This managed to get the old V1 API/payload working again but the V2 one isn't quite working. If you can get that example to work I am happy to help write a unit test. Honestly, I didn't look at why it isn't working much so hopefully it's simple!

Related to activescott/serverless-aws-static-file-handler#118